### PR TITLE
[sentry] enable switching exception type and message

### DIFF
--- a/middleware/sentry.go
+++ b/middleware/sentry.go
@@ -28,6 +28,7 @@ func SetupSentry(dsn string, opts ...SentryOption) error {
 	hook.StacktraceConfiguration.IncludeErrorBreadcrumb = true
 	hook.StacktraceConfiguration.Context = 10
 	hook.StacktraceConfiguration.SendExceptionType = true
+	hook.StacktraceConfiguration.SwitchExceptionTypeAndMessage = true
 
 	for _, o := range opts {
 		err = o(hook)


### PR DESCRIPTION
We started using more logging in a way:
```
log.WithError(err).Error("some message")
```
This leads to unfriendly sentry issues titles: `*client.HttpError Failed request status 404 for url: (/bc/internal/api/v1/latest-block)`

The change in PR switches error type and message: `Failed request status 404 for url: (/bc/internal/api/v1/latest-block) *client.HttpError` 
