### PR TITLE
updated performance metric to report zero

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -98,10 +98,12 @@ func (s *performanceMetric) Duration(start time.Time, lvs []string) {
 
 func (s *performanceMetric) Success(lvs []string) {
 	s.collectors.CounterVec(executionSucceededTotalKey).WithLabelValues(lvs...).Inc()
+	s.collectors.CounterVec(executionFailedTotalKey).WithLabelValues(lvs...).Add(0)
 }
 
 func (s *performanceMetric) Failure(lvs []string) {
 	s.collectors.CounterVec(executionFailedTotalKey).WithLabelValues(lvs...).Inc()
+	s.collectors.CounterVec(executionSucceededTotalKey).WithLabelValues(lvs...).Add(0)
 }
 
 type NullablePerformanceMetric struct{}


### PR DESCRIPTION
The fix make the success/failure metric to appear among pushed values in case where there was no reporting of it yet.

Before, the `<namespace>_execution_failed_total` metric was not pushed, when there was no errors in worker or consumer.
Because initially collector does have a nil value, which is not pushed. It was hard to visualise the chart in Grafana or setup Grafana alerts when metric not available (no data was shown, but flat line at value=0 is preferable)