### PR TITLE
Add health checks to client and consumer

### DIFF
--- a/mq/consumer.go
+++ b/mq/consumer.go
@@ -170,3 +170,11 @@ func (c *consumer) getRemainingRetries(delivery amqp.Delivery) int32 {
 
 	return remainingRetries
 }
+
+func (c *consumer) HealthCheck() error {
+	if err := c.client.HealthCheck(); err != nil {
+		return fmt.Errorf("client health check: %v", err)
+	}
+
+	return nil
+}

--- a/mq/consumer.go
+++ b/mq/consumer.go
@@ -28,6 +28,7 @@ type consumer struct {
 type Consumer interface {
 	Start(ctx context.Context) error
 	Reconnect(ctx context.Context) error
+	HealthCheck() error
 }
 
 type MessageProcessor interface {

--- a/mq/mq.go
+++ b/mq/mq.go
@@ -2,6 +2,7 @@ package mq
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -222,4 +223,12 @@ func publishWithConfig(amqpChan *amqp.Channel, exchange ExchangeName, key Exchan
 
 type ConnectionClient interface {
 	Reconnect(ctx context.Context) error
+}
+
+func (c *Client) HealthCheck() error {
+	if c.conn.IsClosed() {
+		return errors.New("connection is closed")
+	}
+
+	return nil
 }


### PR DESCRIPTION
Add methods to get health status for consumer and client. With this we'll be able to add additional health check logic in caller code. 