### PR TITLE
Make the `ctx` be the first parameter to align the golang style

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -122,23 +122,17 @@ func (r *Request) AddHeader(key, value string) {
 	r.Headers[key] = value
 }
 
-func (r *Request) GetWithContext(result interface{}, path string, query url.Values, ctx context.Context) error {
+func (r *Request) GetWithContext(ctx context.Context, result interface{}, path string, query url.Values) error {
 	uri := r.GetURL(path, query)
-	return r.Execute("GET", uri, nil, result, ctx)
+	return r.Execute(ctx, "GET", uri, nil, result)
 }
 
 func (r *Request) Get(result interface{}, path string, query url.Values) error {
-	uri := r.GetURL(path, query)
-	return r.Execute("GET", uri, nil, result, context.Background())
+	return r.GetWithContext(context.Background(), result, path, query)
 }
 
 func (r *Request) Post(result interface{}, path string, body interface{}) error {
-	buf, err := GetBody(body)
-	if err != nil {
-		return err
-	}
-	uri := r.GetBase(path)
-	return r.Execute("POST", uri, buf, result, context.Background())
+	return r.PostWithContext(context.Background(), result, path, body)
 }
 
 func (r *Request) GetRaw(path string, query url.Values) ([]byte, error) {
@@ -156,16 +150,16 @@ func (r *Request) PostRaw(path string, body interface{}) ([]byte, error) {
 	return r.ExecuteRaw(context.Background(), "POST", uri, buf)
 }
 
-func (r *Request) PostWithContext(result interface{}, path string, body interface{}, ctx context.Context) error {
+func (r *Request) PostWithContext(ctx context.Context, result interface{}, path string, body interface{}) error {
 	buf, err := GetBody(body)
 	if err != nil {
 		return err
 	}
 	uri := r.GetBase(path)
-	return r.Execute("POST", uri, buf, result, ctx)
+	return r.Execute(ctx, "POST", uri, buf, result)
 }
 
-func (r *Request) Execute(method string, url string, body io.Reader, result interface{}, ctx context.Context) error {
+func (r *Request) Execute(ctx context.Context, method string, url string, body io.Reader, result interface{}) error {
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return err
@@ -200,6 +194,7 @@ func (r *Request) ExecuteRaw(ctx context.Context, method string, url string, bod
 
 	return r.execute(ctx, req)
 }
+
 func (r *Request) execute(ctx context.Context, req *http.Request) ([]byte, error) {
 	c := r.HttpClient
 

--- a/client/clientcache.go
+++ b/client/clientcache.go
@@ -24,28 +24,17 @@ type memCache struct {
 }
 
 func (r *Request) PostWithCache(result interface{}, path string, body interface{}, cache time.Duration) error {
-	key := r.generateKey(path, nil, body)
-	err := memoryCache.getCache(key, result)
-	if err == nil {
-		return nil
-	}
-
-	err = r.Post(result, path, body)
-	if err != nil {
-		return err
-	}
-
-	return memoryCache.setCache(key, result, cache)
+	return r.PostWithCacheAndContext(context.Background(), result, path, body, cache)
 }
 
-func (r *Request) PostWithCacheAndContext(result interface{}, path string, body interface{}, cache time.Duration, ctx context.Context) error {
+func (r *Request) PostWithCacheAndContext(ctx context.Context, result interface{}, path string, body interface{}, cache time.Duration) error {
 	key := r.generateKey(path, nil, body)
 	err := memoryCache.getCache(key, result)
 	if err == nil {
 		return nil
 	}
 
-	err = r.PostWithContext(result, path, body, ctx)
+	err = r.PostWithContext(ctx, result, path, body)
 	if err != nil {
 		return err
 	}
@@ -54,28 +43,17 @@ func (r *Request) PostWithCacheAndContext(result interface{}, path string, body 
 }
 
 func (r *Request) GetWithCache(result interface{}, path string, query url.Values, cache time.Duration) error {
-	key := r.generateKey(path, query, nil)
-	err := memoryCache.getCache(key, result)
-	if err == nil {
-		return nil
-	}
-
-	err = r.Get(result, path, query)
-	if err != nil {
-		return err
-	}
-
-	return memoryCache.setCache(key, result, cache)
+	return r.GetWithCacheAndContext(context.Background(), result, path, query, cache)
 }
 
-func (r *Request) GetWithCacheAndContext(result interface{}, path string, query url.Values, cache time.Duration, ctx context.Context) error {
+func (r *Request) GetWithCacheAndContext(ctx context.Context, result interface{}, path string, query url.Values, cache time.Duration) error {
 	key := r.generateKey(path, query, nil)
 	err := memoryCache.getCache(key, result)
 	if err == nil {
 		return nil
 	}
 
-	err = r.Get(result, path, query)
+	err = r.GetWithContext(ctx, result, path, query)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
According to the [documentation](https://pkg.go.dev/context) of the official Golang package:

> Do not store Contexts inside a struct type; instead, pass a Context explicitly to each function that needs it. The Context should be the first parameter, typically named ctx

The PR is to move the `ctx` from the last to the first parameter, and align the official suggestion.