### PR TITLE
Add new middleware for monitoring gin http routes

### DIFF
--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -1,0 +1,36 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/trustwallet/go-libs/metrics"
+)
+
+func MetricsMiddleware(namespace string, labels prometheus.Labels, reg prometheus.Registerer) gin.HandlerFunc {
+	perfMetric := metrics.NewPerformanceMetric(namespace, []string{"request_path"}, labels, reg)
+	return func(c *gin.Context) {
+		matchedRoute := c.FullPath()
+
+		// if route not found call next and immediately return
+		if matchedRoute == "" {
+			c.Next()
+			return
+		}
+
+		startTime := perfMetric.Start(matchedRoute)
+		c.Next()
+		perfMetric.Duration(startTime, matchedRoute)
+
+		statusCode := c.Writer.Status()
+		if successfulHttpStatusCode(statusCode) {
+			perfMetric.Success(matchedRoute)
+		} else {
+			perfMetric.Failure(matchedRoute)
+		}
+	}
+}
+
+func successfulHttpStatusCode(statusCode int) bool {
+	return 200 <= statusCode && statusCode < 300
+}

--- a/middleware/metrics_test.go
+++ b/middleware/metrics_test.go
@@ -61,8 +61,15 @@ func TestMetricsMiddleware(t *testing.T) {
 
 		require.Len(t, metricFamily.Metric, len(expectedLabelCounterMap))
 		for _, metric := range metricFamily.Metric {
-			require.Len(t, metric.Label, 1)
-			require.Equal(t, float64(expectedLabelCounterMap[*metric.Label[0].Value]), *metric.Counter.Value)
+			require.Len(t, metric.Label, 2)
+			var chosenLabelIdx = -1
+			for idx, label := range metric.Label {
+				if *label.Name == labelPath {
+					chosenLabelIdx = idx
+				}
+			}
+			require.NotEqual(t, -1, chosenLabelIdx)
+			require.Equal(t, float64(expectedLabelCounterMap[*metric.Label[chosenLabelIdx].Value]), *metric.Counter.Value)
 		}
 	}
 }

--- a/middleware/metrics_test.go
+++ b/middleware/metrics_test.go
@@ -1,0 +1,68 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricsMiddleware(t *testing.T) {
+	r := prometheus.NewRegistry()
+	router := gin.New()
+	router.Use(MetricsMiddleware("", nil, r))
+
+	successGroup := router.Group("/success")
+	successGroup.GET("/:test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, struct{}{})
+	})
+
+	successGroup.GET("", func(c *gin.Context) {
+		c.JSON(http.StatusOK, struct{}{})
+	})
+
+	router.GET("/error", func(c *gin.Context) {
+		_ = c.AbortWithError(http.StatusInternalServerError, errors.New("oops error"))
+	})
+
+	// 2 successes, 1 errors
+	_ = performRequest("GET", "/success?haha=1&hoho=2", router)
+	_ = performRequest("GET", "/error?hehe=1&huhu=3", router)
+	_ = performRequest("GET", "/success/hihi", router)
+
+	metricFamilies, err := r.Gather()
+	require.NoError(t, err)
+
+	const executionFailedTotal = "execution_failed_total"
+	const executionSucceededTotal = "execution_succeeded_total"
+
+	// metricFamily.Name --> label --> counter value
+	expected := map[string]map[string]int{
+		executionSucceededTotal: {
+			"/success":       1,
+			"/success/:test": 1,
+			"/error":         0,
+		},
+		executionFailedTotal: {
+			"/success":       0,
+			"/success/:test": 0,
+			"/error":         1,
+		},
+	}
+
+	for _, metricFamily := range metricFamilies {
+		expectedLabelCounterMap, ok := expected[*metricFamily.Name]
+		if !ok {
+			continue
+		}
+
+		require.Len(t, metricFamily.Metric, len(expectedLabelCounterMap))
+		for _, metric := range metricFamily.Metric {
+			require.Len(t, metric.Label, 1)
+			require.Equal(t, float64(expectedLabelCounterMap[*metric.Label[0].Value]), *metric.Counter.Value)
+		}
+	}
+}


### PR DESCRIPTION
Part of: https://github.com/trustwallet/backend/issues/1843

### This PR
This PR adds middleware for monitoring gin http routes. It mainly comprised of:
- [MetricsMiddleware function](https://github.com/trustwallet/go-libs/pull/171/files#diff-dbb730e5adef2e6dc425d22a920aab9293b9bb063d87886a072d99491ae274a1R13)
- [Changing PerformanceMetric to allow dynamic labels](https://github.com/trustwallet/go-libs/pull/171/files#diff-d715f391f2ffa038c3167bfea1adf741c1f5e39f08349fbbacab780a594146a4R19-R22)

### Sample Usage 

```
router := api.GetGinRouter()
if config.Default.Metrics.Enabled {
    initMetrics(router)
}

func initMetrics(router *gin.Engine) {
	metrics.InitHandler(router, config.Default.Metrics.Path)
	router.Use(middleware.MetricsMiddleware(appName, nil, prometheus.DefaultRegisterer))
}

```

### Local Test

I ran devices API, made sample requests, and successfully got this `/metrics` output
<img width="1326" alt="Screen Shot 2022-10-08 at 01 35 38" src="https://user-images.githubusercontent.com/4551581/194616825-2c8c717a-a3c4-4cb1-9189-df63510a913c.png">
