### PR TITLE
Add hmac signature gin handler middleware

### DIFF
--- a/gin/hmac.go
+++ b/gin/hmac.go
@@ -1,0 +1,97 @@
+package gin
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+var ErrInvalidSignature = errors.New("invalid signature")
+
+type StrFromCtx func(c *gin.Context) (string, error)
+
+// HmacDefaultSignatureHeader defines the default header name where clients should place the signature.
+const HmacDefaultSignatureHeader = "X-REQ-SIG"
+
+type HmacSha256Verifier struct {
+	keys       [][]byte
+	sigFN      StrFromCtx
+	sigEncoder func([]byte) string
+}
+
+func NewHmacSha256Verifier(keys [][]byte) *HmacSha256Verifier {
+	return &HmacSha256Verifier{
+		keys: keys,
+		sigFN: func(c *gin.Context) (string, error) {
+			return c.GetHeader(HmacDefaultSignatureHeader), nil
+		},
+		sigEncoder: func(b []byte) string {
+			return base64.StdEncoding.EncodeToString(b)
+		},
+	}
+}
+
+// WithSigFunction can be used to override signature location.
+// As a query string param for example:
+//
+//	func(c *gin.Context) (string, error) {
+//		return c.Query("sig"), nil
+//	}
+func (v *HmacSha256Verifier) WithSigFunction(sigFN StrFromCtx) *HmacSha256Verifier {
+	v.sigFN = sigFN
+	return v
+}
+
+// WithSigEncoder can be used to override default signature encoder (base64).
+func (v *HmacSha256Verifier) WithSigEncoder(e func(b []byte) string) *HmacSha256Verifier {
+	v.sigEncoder = e
+	return v
+}
+
+// SignedHandler can be used to construct signed handlers.
+// plaintextFN defines the message that should be signed by clients.
+// For example:
+//
+//	func(c *gin.Context) (string, error) {
+//		return c.Query("asset") + ":" + c.Query("coin"), nil
+//	}
+func (v *HmacSha256Verifier) SignedHandler(h gin.HandlerFunc, plaintextFN StrFromCtx) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		plaintext, err := plaintextFN(c)
+		if err != nil {
+			_ = c.AbortWithError(http.StatusBadRequest, errors.New("cannot extract plaintext"))
+			return
+		}
+
+		sig, err := v.sigFN(c)
+		if err != nil {
+			_ = c.AbortWithError(http.StatusBadRequest, errors.New("cannot extract signature"))
+			return
+		}
+
+		if err := v.verifySignature([]byte(plaintext), sig); err != nil {
+			_ = c.AbortWithError(http.StatusUnauthorized, errors.New("cannot verify signature"))
+			return
+		}
+
+		h(c)
+	}
+}
+
+func (v *HmacSha256Verifier) verifySignature(msg []byte, sig string) error {
+	for _, signatureKey := range v.keys {
+		h := hmac.New(sha256.New, signatureKey)
+		h.Write(msg)
+		sum := h.Sum(nil)
+		encoded := v.sigEncoder(sum)
+		if sig == encoded {
+			return nil
+		}
+	}
+
+	return ErrInvalidSignature
+}

--- a/gin/hmac.go
+++ b/gin/hmac.go
@@ -23,9 +23,14 @@ type HmacSha256Verifier struct {
 	sigEncoder func([]byte) string
 }
 
-func NewHmacSha256Verifier(keys [][]byte) *HmacSha256Verifier {
+func NewHmacSha256Verifier(keys []string) *HmacSha256Verifier {
+	keysB := make([][]byte, len(keys))
+	for i := range keys {
+		keysB[i] = []byte(keys[i])
+	}
+
 	return &HmacSha256Verifier{
-		keys: keys,
+		keys: keysB,
 		sigFN: func(c *gin.Context) (string, error) {
 			return c.GetHeader(HmacDefaultSignatureHeader), nil
 		},

--- a/gin/hmac_test.go
+++ b/gin/hmac_test.go
@@ -37,7 +37,7 @@ func createTestContext(t *testing.T, w *httptest.ResponseRecorder, rawURL string
 
 func TestHmacVerifier(t *testing.T) {
 	verifier := NewHmacSha256Verifier(
-		[][]byte{[]byte("some-key"), []byte("some-other-key"), []byte("k")},
+		[]string{"some-key", "some-other-key", "k"},
 	)
 
 	someRouteHandler := func(c *gin.Context) { c.Status(http.StatusOK) }
@@ -85,7 +85,7 @@ func TestHmacVerifier(t *testing.T) {
 
 	t.Run("bad request when signature cannot be extracted", func(t *testing.T) {
 		h := NewHmacSha256Verifier(
-			[][]byte{[]byte("some-key"), []byte("some-other-key"), []byte("k")},
+			[]string{"some-key", "some-other-key", "k"},
 		).WithSigFunction(func(c *gin.Context) (string, error) {
 			return "", errors.New("some error")
 		}).SignedHandler(someRouteHandler, func(c *gin.Context) (string, error) {
@@ -100,7 +100,7 @@ func TestHmacVerifier(t *testing.T) {
 
 	t.Run("bad request when plaintext cannot be extracted", func(t *testing.T) {
 		h := NewHmacSha256Verifier(
-			[][]byte{[]byte("some-key"), []byte("some-other-key"), []byte("k")},
+			[]string{"some-key", "some-other-key", "k"},
 		).SignedHandler(someRouteHandler, func(c *gin.Context) (string, error) {
 			return "", errors.New("plaintext cannot be extracted")
 		})
@@ -113,7 +113,7 @@ func TestHmacVerifier(t *testing.T) {
 
 	t.Run("override signature encoder", func(t *testing.T) {
 		h := NewHmacSha256Verifier(
-			[][]byte{[]byte("some-key"), []byte("some-other-key"), []byte("k")},
+			[]string{"some-key", "some-other-key", "k"},
 		).WithSigEncoder(func(b []byte) string {
 			return "some-static-sig"
 		}).SignedHandler(someRouteHandler, func(c *gin.Context) (string, error) {
@@ -132,9 +132,9 @@ func TestHmacVerifier(t *testing.T) {
 func BenchmarkHmacVerifier_verifySignature(b *testing.B) {
 	const msgByteSize = 512
 	const numValidKeys = 100
-	validKeys := make([][]byte, numValidKeys)
+	validKeys := make([]string, numValidKeys)
 	for i := range validKeys {
-		validKeys[i] = []byte(fmt.Sprintf("key-%d", i))
+		validKeys[i] = fmt.Sprintf("key-%d", i)
 	}
 	verifier := NewHmacSha256Verifier(validKeys)
 

--- a/gin/hmac_test.go
+++ b/gin/hmac_test.go
@@ -1,0 +1,158 @@
+package gin
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"gotest.tools/assert"
+)
+
+func createTestContext(t *testing.T, w *httptest.ResponseRecorder, rawURL string, headers map[string]string) *gin.Context {
+	c, _ := gin.CreateTestContext(w)
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.Request = &http.Request{
+		URL:    u,
+		Header: make(http.Header),
+	}
+	for k, v := range headers {
+		c.Request.Header.Add(k, v)
+	}
+
+	return c
+}
+
+func TestHmacVerifier(t *testing.T) {
+	verifier := NewHmacSha256Verifier(
+		[][]byte{[]byte("some-key"), []byte("some-other-key"), []byte("k")},
+	)
+
+	someRouteHandler := func(c *gin.Context) { c.Status(http.StatusOK) }
+	signedRouteHandler := verifier.SignedHandler(someRouteHandler, func(c *gin.Context) (string, error) {
+		pt := c.Query("asset") + ":" + c.Query("coin")
+		return pt, nil
+	})
+
+	t.Run("unauthorized when signature not provided", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		signedRouteHandler(createTestContext(t, w, "", nil))
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("signature verification success for all keys", func(t *testing.T) {
+		asset := "123"
+		coin := "60"
+		plainText := asset + ":" + coin
+		rawURL := fmt.Sprintf("http://does.not.matter?asset=%s&coin=%s", asset, coin)
+
+		for _, k := range verifier.keys {
+			h := hmac.New(sha256.New, k)
+			h.Write([]byte(plainText))
+			sig := base64.StdEncoding.EncodeToString(h.Sum(nil))
+
+			w := httptest.NewRecorder()
+			signedRouteHandler(createTestContext(t, w, rawURL, map[string]string{
+				"X-REQ-SIG": sig,
+			}))
+			assert.Equal(t, http.StatusOK, w.Code)
+		}
+	})
+
+	t.Run("signature verification failure", func(t *testing.T) {
+		asset := "123"
+		coin := "60"
+		rawURL := fmt.Sprintf("http://does.not.matter?asset=%s&coin=%s", asset, coin)
+
+		w := httptest.NewRecorder()
+		signedRouteHandler(createTestContext(t, w, rawURL, map[string]string{
+			"X-REQ-SIG": "JBdWTO5yR2GB0TOT8YcM7AjWaJaMtVrAFOYUlZRNlYg=",
+		}))
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("bad request when signature cannot be extracted", func(t *testing.T) {
+		h := NewHmacSha256Verifier(
+			[][]byte{[]byte("some-key"), []byte("some-other-key"), []byte("k")},
+		).WithSigFunction(func(c *gin.Context) (string, error) {
+			return "", errors.New("some error")
+		}).SignedHandler(someRouteHandler, func(c *gin.Context) (string, error) {
+			return "whatever", nil
+		})
+
+		rawURL := fmt.Sprintf("http://does.not.matter")
+		w := httptest.NewRecorder()
+		h(createTestContext(t, w, rawURL, map[string]string{}))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("bad request when plaintext cannot be extracted", func(t *testing.T) {
+		h := NewHmacSha256Verifier(
+			[][]byte{[]byte("some-key"), []byte("some-other-key"), []byte("k")},
+		).SignedHandler(someRouteHandler, func(c *gin.Context) (string, error) {
+			return "", errors.New("plaintext cannot be extracted")
+		})
+
+		rawURL := fmt.Sprintf("http://does.not.matter")
+		w := httptest.NewRecorder()
+		h(createTestContext(t, w, rawURL, map[string]string{}))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("override signature encoder", func(t *testing.T) {
+		h := NewHmacSha256Verifier(
+			[][]byte{[]byte("some-key"), []byte("some-other-key"), []byte("k")},
+		).WithSigEncoder(func(b []byte) string {
+			return "some-static-sig"
+		}).SignedHandler(someRouteHandler, func(c *gin.Context) (string, error) {
+			return "whatever", nil
+		})
+
+		rawURL := fmt.Sprintf("http://does.not.matter")
+		w := httptest.NewRecorder()
+		h(createTestContext(t, w, rawURL, map[string]string{
+			HmacDefaultSignatureHeader: "some-static-sig",
+		}))
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+}
+
+func BenchmarkHmacVerifier_verifySignature(b *testing.B) {
+	const msgByteSize = 512
+	const numValidKeys = 100
+	validKeys := make([][]byte, numValidKeys)
+	for i := range validKeys {
+		validKeys[i] = []byte(fmt.Sprintf("key-%d", i))
+	}
+	verifier := NewHmacSha256Verifier(validKeys)
+
+	for i := 0; i < b.N; i++ {
+		msg := randBytes(msgByteSize)
+		sig := string(randBytes(64))
+		err := verifier.verifySignature(msg, sig)
+		if err == nil {
+			b.Errorf("expected error")
+		}
+	}
+}
+
+func randBytes(n int) []byte {
+	var charset = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return b
+}


### PR DESCRIPTION
Adds support for defining gin routes that are verified with hmac sha256 signatures.

Example:

```go
v := NewHmacShaVerifier("some-valid-key", "some-other-valid-key")

signedHandler := v.SignedHandler(
   myApi.SomeHandler, // the handler we want to apply hmac signature on
   func(c *gin.Context) (string, error) { return c.Query("ts") + c.Query("asset") + c.Query("coin"), nil } // define plaintext msg
)
```

closes #166 