### PR TITLE
add struct Path to specify template for monitoring

### DIFF
--- a/client/client_metrics.go
+++ b/client/client_metrics.go
@@ -45,15 +45,15 @@ func newHttpClientMetrics(constLabels prometheus.Labels) *httpClientMetrics {
 	return m
 }
 
-func (metric *httpClientMetrics) observeDuration(req *http.Request, startTime time.Time) {
-	url := getHttpReqMetricUrl(req)
+func (metric *httpClientMetrics) observeDuration(req *http.Request, pathTemplate string, startTime time.Time) {
+	url := getHttpReqMetricUrl(req, pathTemplate)
 	method := req.Method
 
 	metric.durationSeconds.WithLabelValues(url, method).Observe(time.Since(startTime).Seconds())
 }
 
-func (metric *httpClientMetrics) observeResult(req *http.Request, resp *http.Response, err error) {
-	url := getHttpReqMetricUrl(req)
+func (metric *httpClientMetrics) observeResult(req *http.Request, pathTemplate string, resp *http.Response, err error) {
+	url := getHttpReqMetricUrl(req, pathTemplate)
 	method := req.Method
 	status := getHttpRespMetricStatus(resp, err)
 
@@ -72,8 +72,8 @@ func (metric *httpClientMetrics) Collect(metrics chan<- prometheus.Metric) {
 	metric.requestTotal.Collect(metrics)
 }
 
-func getHttpReqMetricUrl(req *http.Request) string {
-	return fmt.Sprintf("%s://%s%s", req.URL.Scheme, req.URL.Host, req.URL.Path)
+func getHttpReqMetricUrl(req *http.Request, pathTemplate string) string {
+	return fmt.Sprintf("%s://%s%s", req.URL.Scheme, req.URL.Host, pathTemplate)
 }
 
 func getHttpRespMetricStatus(resp *http.Response, err error) string {

--- a/client/clientcache.go
+++ b/client/clientcache.go
@@ -23,12 +23,12 @@ type memCache struct {
 	cache *cache.Cache
 }
 
-func (r *Request) PostWithCache(result interface{}, path string, body interface{}, cache time.Duration) error {
+func (r *Request) PostWithCache(result interface{}, path Path, body interface{}, cache time.Duration) error {
 	return r.PostWithCacheAndContext(context.Background(), result, path, body, cache)
 }
 
-func (r *Request) PostWithCacheAndContext(ctx context.Context, result interface{}, path string, body interface{}, cache time.Duration) error {
-	key := r.generateKey(path, nil, body)
+func (r *Request) PostWithCacheAndContext(ctx context.Context, result interface{}, path Path, body interface{}, cache time.Duration) error {
+	key := r.generateKey(path.String(), nil, body)
 	err := memoryCache.getCache(key, result)
 	if err == nil {
 		return nil
@@ -42,12 +42,12 @@ func (r *Request) PostWithCacheAndContext(ctx context.Context, result interface{
 	return memoryCache.setCache(key, result, cache)
 }
 
-func (r *Request) GetWithCache(result interface{}, path string, query url.Values, cache time.Duration) error {
+func (r *Request) GetWithCache(result interface{}, path Path, query url.Values, cache time.Duration) error {
 	return r.GetWithCacheAndContext(context.Background(), result, path, query, cache)
 }
 
-func (r *Request) GetWithCacheAndContext(ctx context.Context, result interface{}, path string, query url.Values, cache time.Duration) error {
-	key := r.generateKey(path, query, nil)
+func (r *Request) GetWithCacheAndContext(ctx context.Context, result interface{}, path Path, query url.Values, cache time.Duration) error {
+	key := r.generateKey(path.String(), query, nil)
 	err := memoryCache.getCache(key, result)
 	if err == nil {
 		return nil

--- a/client/http_path.go
+++ b/client/http_path.go
@@ -1,0 +1,24 @@
+package client
+
+import "fmt"
+
+type Path struct {
+	template string
+	values   []any
+}
+
+func NewStaticPath(path string) Path {
+	return Path{template: path}
+}
+
+func NewEmptyPath() Path {
+	return Path{}
+}
+
+func NewPath(template string, values []any) Path {
+	return Path{template: template, values: values}
+}
+
+func (p Path) String() string {
+	return fmt.Sprintf(p.template, p.values...)
+}

--- a/client/http_path_test.go
+++ b/client/http_path_test.go
@@ -1,0 +1,69 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPath_String(t *testing.T) {
+	type fields struct {
+		template string
+		values   []any
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "empty template, empty values",
+			fields: fields{
+				template: "",
+				values:   nil,
+			},
+			want: "",
+		},
+		{
+			name: "empty template only",
+			fields: fields{
+				template: "",
+				values:   []any{1, 2, 3},
+			},
+			want: "%!(EXTRA int=1, int=2, int=3)",
+		},
+		{
+			name: "empty values only",
+			fields: fields{
+				template: "/api/v1/blocks",
+				values:   nil,
+			},
+			want: "/api/v1/blocks",
+		},
+		{
+			name: "both exist",
+			fields: fields{
+				template: "/nft/collections/%s/tokens",
+				values:   []any{"123"},
+			},
+			want: "/nft/collections/123/tokens",
+		},
+		{
+			name: "missing values",
+			fields: fields{
+				template: "/nft/collections/%s/tokens/%d",
+				values:   []any{"123"},
+			},
+			want: "/nft/collections/123/tokens/%!d(MISSING)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Path{
+				template: tt.fields.template,
+				values:   tt.fields.values,
+			}
+			assert.Equalf(t, tt.want, p.String(), "String()")
+		})
+	}
+}

--- a/client/jsonrpc.go
+++ b/client/jsonrpc.go
@@ -43,7 +43,7 @@ type (
 func (r *Request) RpcCall(result interface{}, method string, params interface{}) error {
 	req := &RpcRequest{JsonRpc: JsonRpcVersion, Method: method, Params: params, Id: genID()}
 	var resp *RpcResponse
-	err := r.Post(&resp, "", req)
+	err := r.Post(&resp, NewEmptyPath(), req)
 	if err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func (r *Request) RpcCall(result interface{}, method string, params interface{})
 func (r *Request) RpcCallRaw(method string, params interface{}) ([]byte, error) {
 	req := &RpcRequest{JsonRpc: JsonRpcVersion, Method: method, Params: params, Id: genID()}
 	var resp *RpcResponseRaw
-	err := r.Post(&resp, "", req)
+	err := r.Post(&resp, NewEmptyPath(), req)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (r *Request) RpcCallRaw(method string, params interface{}) ([]byte, error) 
 
 func (r *Request) RpcBatchCall(requests RpcRequests) ([]RpcResponse, error) {
 	var resp []RpcResponse
-	err := r.Post(&resp, "", requests.fillDefaultValues())
+	err := r.Post(&resp, NewEmptyPath(), requests.fillDefaultValues())
 	if err != nil {
 		return nil, err
 	}

--- a/eventer/client.go
+++ b/eventer/client.go
@@ -28,6 +28,6 @@ func Init(url string, limit int) {
 }
 
 func (c Client) SendBatch(events []Event) (status Status, err error) {
-	err = senderClient.Post(&status, "", events)
+	err = senderClient.Post(&status, client.NewEmptyPath(), events)
 	return
 }

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/trustwallet/go-libs/client"
 )
 
@@ -26,10 +27,10 @@ func TestCreateMockedAPI(t *testing.T) {
 
 	server := httptest.NewServer(CreateMockedAPI(data))
 	defer server.Close()
-	client := client.InitClient(server.URL, nil)
+	c := client.InitClient(server.URL, nil)
 
 	var resp response
-	err := client.Get(&resp, "1", nil)
+	err := c.Get(&resp, client.NewStaticPath("1"), nil)
 
 	assert.Nil(t, err)
 	assert.True(t, resp.Status)


### PR DESCRIPTION
### Problem

I am trying to avoid labels with high cardinality because it is costly to monitor in prometheus.
so if possible, i want to monitor the "template" path only. For example:
- This is better /v2/generations/height/%d
- This will produce high cardinality label: /v2/generations/height/123

### Proposed Solution

Replaces all parameters to `path string` to `path Path` where `Path` is a struct that contains a template:
```
type Path struct {
	template string
	values   []any
}

func NewStaticPath(path string) Path {
	return Path{template: path}
}
func NewPath(template string, values []any) Path {
	return Path{template: template, values: values}
}

func (p Path) String() string {
	return fmt.Sprintf(p.template, p.values...)
}
```