### PR TITLE
disable path monitoring temporarily

### DIFF
--- a/client/client_metrics.go
+++ b/client/client_metrics.go
@@ -73,7 +73,7 @@ func (metric *httpClientMetrics) Collect(metrics chan<- prometheus.Metric) {
 }
 
 func getHttpReqMetricUrl(req *http.Request) string {
-	return fmt.Sprintf("%s://%s%s", req.URL.Scheme, req.URL.Host, req.URL.Path)
+	return fmt.Sprintf("%s://%s", req.URL.Scheme, req.URL.Host)
 }
 
 func getHttpRespMetricStatus(resp *http.Response, err error) string {

--- a/client/client_metrics_test.go
+++ b/client/client_metrics_test.go
@@ -116,7 +116,7 @@ func Test_getHttpReqMetricUrl(t *testing.T) {
 					return req
 				}(),
 			},
-			want: "http://www.example.com/abc/def",
+			want: "http://www.example.com",
 		},
 		{
 			name: "example.com with query params",
@@ -126,7 +126,7 @@ func Test_getHttpReqMetricUrl(t *testing.T) {
 					return req
 				}(),
 			},
-			want: "http://www.example.com/abc",
+			want: "http://www.example.com",
 		},
 		{
 			name: "example.com with query params and fragments",


### PR DESCRIPTION
### Problem
I am trying to avoid labels with high cardinality because it is costly to monitor in prometheus.
so if possible, i want to monitor the "template" path only. For example:
- This is better `/v2/generations/height/%d`
- This will produce high cardinality label: `/v2/generations/height/123`

### This PR
This PR disables monitoring the URL temporarily, until I found a better approach