### PR TITLE
Add Builder Pattern in http client

### DIFF
--- a/client/client_execute.go
+++ b/client/client_execute.go
@@ -1,0 +1,143 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Execute executes http request as described in Req.
+//
+// If Req.WriteTo is specified, it will also populate the resultContainer
+func (r *Request) Execute(ctx context.Context, req *Req) ([]byte, error) {
+	request, err := r.constructHttpRequest(ctx, req)
+
+	startTime := time.Now()
+	res, err := r.HttpClient.Do(request)
+	r.reportMonitoringMetricsIfEnabled(startTime, request, req, res, err)
+	if err != nil {
+		return nil, err
+	}
+
+	err = r.HttpErrorHandler(res, request.URL.String())
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusBadRequest {
+		return nil, &HttpError{
+			StatusCode: res.StatusCode,
+			URL:        *request.URL,
+			Body:       b,
+		}
+	}
+
+	err = populateResultContainer(b, req.resultContainer)
+	if err != nil {
+		return b, err
+	}
+
+	return b, nil
+}
+
+// constructHttpRequest constructs a http.Request object from description in Req and common headers in r.
+func (r *Request) constructHttpRequest(ctx context.Context, req *Req) (*http.Request, error) {
+	body, err := GetBody(req.body)
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := http.NewRequestWithContext(ctx, req.method, r.GetURL(req.path.String(), req.query), body)
+	if err != nil {
+		return nil, err
+	}
+
+	r.setRequestHeaders(request, req)
+	return request, nil
+}
+
+func (r *Request) reportMonitoringMetricsIfEnabled(
+	startTime time.Time, request *http.Request,
+	req *Req, res *http.Response, resErr error,
+) {
+	if r.metricsEnabled() {
+		url := getHttpReqMetricUrl(request, getMonitoredPathTemplateIfEnabled(req))
+		method := request.Method
+		name := req.metricName
+		status := getHttpRespMetricStatus(res, resErr)
+
+		r.httpMetrics.observeDuration(url, method, name, startTime)
+		r.httpMetrics.observeResult(url, method, name, status)
+	}
+}
+
+// setRequestHeaders sets the given httpRequest with the common headers from the client, and headers specified in Req.
+// If there are duplicated headers, the headers specified in Req takes precedence.
+func (r *Request) setRequestHeaders(httpRequest *http.Request, req *Req) {
+	headersSlice := []map[string]string{r.Headers, req.headers}
+	for _, headers := range headersSlice {
+		for key, value := range headers {
+			httpRequest.Header.Set(key, value)
+		}
+	}
+}
+
+// populateResultContainer populates the given resultContainer if it's not nil
+func populateResultContainer(b []byte, resultContainer any) error {
+	if resultContainer != nil {
+		err := json.Unmarshal(b, resultContainer)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getMonitoredPathTemplateIfEnabled(req *Req) string {
+	if !req.pathMetricEnabled {
+		return ""
+	}
+	return req.path.template
+}
+
+func (r *Request) GetBase(path string) string {
+	baseURL := strings.TrimRight(r.BaseURL, "/")
+	if path == "" {
+		return baseURL
+	}
+	path = strings.TrimLeft(path, "/")
+	return fmt.Sprintf("%s/%s", baseURL, path)
+}
+
+func (r *Request) GetURL(path string, query url.Values) string {
+	baseURL := r.GetBase(path)
+	if query == nil {
+		return baseURL
+	}
+	queryStr := query.Encode()
+	return fmt.Sprintf("%s?%s", baseURL, queryStr)
+}
+
+func (r *Request) metricsEnabled() bool {
+	return r.httpMetrics != nil
+}
+
+func GetBody(body interface{}) (buf io.ReadWriter, err error) {
+	if body != nil {
+		buf = new(bytes.Buffer)
+		err = json.NewEncoder(buf).Encode(body)
+	}
+	return
+}

--- a/client/client_helper.go
+++ b/client/client_helper.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+)
+
+// Deprecated: Left as backwards-compatibility. Use Execute(NewReqBuilder()) for better APIs and monitoring
+func (r *Request) GetWithContext(ctx context.Context, result interface{}, path string, query url.Values) error {
+	_, err := r.Execute(ctx, NewReqBuilder().
+		Method(http.MethodGet).
+		PathStatic(path).
+		Query(query).
+		WriteTo(result).
+		pathMetricEnabled(false).
+		Build())
+	return err
+}
+
+// Deprecated: Left as backwards-compatibility. Use Execute(NewReqBuilder()) for better APIs and monitoring
+func (r *Request) Get(result interface{}, path string, query url.Values) error {
+	return r.GetWithContext(context.Background(), result, path, query)
+}
+
+// Deprecated: Left as backwards-compatibility. Use Execute(NewReqBuilder()) for better APIs and monitoring
+func (r *Request) Post(result interface{}, path string, body interface{}) error {
+	return r.PostWithContext(context.Background(), result, path, body)
+}
+
+// Deprecated: Left as backwards-compatibility. Use Execute(NewReqBuilder()) for better APIs and monitoring
+func (r *Request) GetRaw(path string, query url.Values) ([]byte, error) {
+	return r.Execute(context.Background(), NewReqBuilder().
+		Method(http.MethodGet).
+		PathStatic(path).
+		Query(query).
+		pathMetricEnabled(false).
+		Build())
+}
+
+// Deprecated: Left as backwards-compatibility. Use Execute(NewReqBuilder()) for better APIs and monitoring
+func (r *Request) PostRaw(path string, body interface{}) ([]byte, error) {
+	return r.Execute(context.Background(), NewReqBuilder().
+		Method(http.MethodPost).
+		PathStatic(path).
+		Body(body).
+		pathMetricEnabled(false).
+		Build())
+}
+
+// Deprecated: Left as backwards-compatibility. Use Execute(NewReqBuilder()) for better APIs and monitoring
+func (r *Request) PostWithContext(ctx context.Context, result interface{}, path string, body interface{}) error {
+	_, err := r.Execute(ctx, NewReqBuilder().
+		Method(http.MethodPost).
+		PathStatic(path).
+		Body(body).
+		WriteTo(result).
+		pathMetricEnabled(false).
+		Build())
+	return err
+}

--- a/client/client_helper_test.go
+++ b/client/client_helper_test.go
@@ -1,0 +1,201 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequest_Get(t *testing.T) {
+	const aBaseURL = "http://www.example.com"
+
+	var responses = []string{
+		`{"status": "success"}`,
+		`{"status": "success with data"}`,
+	}
+
+	router := gin.New()
+	router.GET("/test", func(c *gin.Context) {
+		c.Data(http.StatusOK, gin.MIMEJSON, []byte(responses[0]))
+	})
+
+	router.GET("/path/with/query", func(c *gin.Context) {
+		queryData := c.Query("data")
+		if queryData != "testdata" {
+			_ = c.AbortWithError(http.StatusBadRequest, errors.New("ooops"))
+			return
+		}
+		c.Data(http.StatusOK, gin.MIMEJSON, []byte(responses[1]))
+	})
+
+	httpClient := httpClientFromGinEngine(t, router, aBaseURL)
+	c := InitClient(aBaseURL, nil, WithHttpClient(httpClient))
+
+	tests := []struct {
+		name         string
+		path         string
+		query        url.Values
+		expectedResp string
+		assertError  require.ErrorAssertionFunc
+	}{
+		{
+			name:         "happy path simple",
+			path:         "/test",
+			query:        nil,
+			expectedResp: responses[0],
+			assertError:  require.NoError,
+		},
+		{
+			name: "happy path with query string",
+			path: "/path/with/query",
+			query: func() url.Values {
+				v := url.Values{}
+				v.Set("data", "testdata")
+				return v
+			}(),
+			expectedResp: responses[1],
+			assertError:  require.NoError,
+		},
+		{
+			name: "error path",
+			path: "/path/with/query",
+			query: func() url.Values {
+				v := url.Values{}
+				v.Set("data", "wrong_value")
+				return v
+			}(),
+			expectedResp: "{}",
+			assertError:  require.Error,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Run("GetWithContext", func(t *testing.T) {
+				resObj := map[string]string{}
+				err := c.GetWithContext(context.Background(), &resObj, test.path, test.query)
+				test.assertError(t, err)
+
+				actualRespStr, err := json.Marshal(resObj)
+				require.NoError(t, err)
+				require.JSONEq(t, test.expectedResp, string(actualRespStr))
+			})
+
+			t.Run("GetRaw", func(t *testing.T) {
+				bytes, err := c.GetRaw(test.path, test.query)
+				test.assertError(t, err)
+
+				if string(bytes) == "" {
+					bytes = []byte("{}")
+				}
+				require.JSONEq(t, test.expectedResp, string(bytes))
+			})
+		})
+	}
+}
+
+func TestRequest_Post(t *testing.T) {
+	const aBaseURL = "http://www.example.com"
+
+	type reqStruct struct {
+		Data string `json:"data"`
+	}
+	var responses = []string{
+		`{"status": "success"}`,
+		`{"status": "success with request"}`,
+	}
+
+	router := gin.New()
+	router.POST("/test", func(c *gin.Context) {
+		c.Data(http.StatusOK, gin.MIMEJSON, []byte(responses[0]))
+	})
+
+	router.POST("/a/very/long/path", func(c *gin.Context) {
+		var req reqStruct
+		_ = c.Bind(&req)
+		if req.Data != "testdata" {
+			_ = c.AbortWithError(http.StatusBadRequest, errors.New("ooops"))
+			return
+		}
+		c.Data(http.StatusOK, gin.MIMEJSON, []byte(responses[1]))
+	})
+
+	httpClient := httpClientFromGinEngine(t, router, aBaseURL)
+	c := InitJSONClient(aBaseURL, nil, WithHttpClient(httpClient))
+
+	tests := []struct {
+		name         string
+		path         string
+		body         any
+		expectedResp string
+		assertError  require.ErrorAssertionFunc
+	}{
+		{
+			name:         "happy path no request",
+			path:         "/test",
+			expectedResp: responses[0],
+			body:         nil,
+			assertError:  require.NoError,
+		},
+		{
+			name:         "happy path - long path, with request",
+			path:         "/a/very/long/path",
+			expectedResp: responses[1],
+			body:         reqStruct{Data: "testdata"},
+			assertError:  require.NoError,
+		},
+		{
+			name:         "error path",
+			path:         "/path/with/query",
+			body:         reqStruct{Data: "wrong_data"},
+			expectedResp: "{}",
+			assertError:  require.Error,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Run("PostWithContext", func(t *testing.T) {
+				resObj := map[string]string{}
+				err := c.PostWithContext(context.Background(), &resObj, test.path, test.body)
+				test.assertError(t, err)
+
+				actualRespStr, err := json.Marshal(resObj)
+				require.NoError(t, err)
+				require.JSONEq(t, test.expectedResp, string(actualRespStr))
+			})
+
+			t.Run("PostRaw", func(t *testing.T) {
+				bytes, err := c.PostRaw(test.path, test.body)
+				test.assertError(t, err)
+
+				if string(bytes) == "" {
+					bytes = []byte("{}")
+				}
+				require.JSONEq(t, test.expectedResp, string(bytes))
+			})
+		})
+	}
+}
+
+func httpClientFromGinEngine(t *testing.T, engine *gin.Engine, baseURL string) *http.Client {
+	return &http.Client{
+		Transport: RoundTripperFunc(func(request *http.Request) (*http.Response, error) {
+			require.Equal(t, baseURL, fmt.Sprintf("%s://%s", request.URL.Scheme, request.URL.Host))
+
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, request)
+			res := w.Result()
+			res.Request = request
+			return res, nil
+		}),
+	}
+}

--- a/client/client_metrics_test.go
+++ b/client/client_metrics_test.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -24,10 +26,6 @@ func TestClientMetrics(t *testing.T) {
 		path5xx = "/5xx"
 		pathErr = "/err"
 	)
-
-	type Response struct {
-		Data string
-	}
 
 	reg := prometheus.NewPedanticRegistry()
 
@@ -55,53 +53,79 @@ func TestClientMetrics(t *testing.T) {
 			}),
 		}))
 
-	var resp Response
+	_, _ = client.Execute(context.Background(), NewReqBuilder().Method(http.MethodGet).PathStatic(pathOk).Build())
+	_, _ = client.Execute(context.Background(), NewReqBuilder().Method(http.MethodGet).PathStatic(path5xx).Build())
+	_, _ = client.Execute(context.Background(), NewReqBuilder().Method(http.MethodGet).PathStatic(pathErr).Build())
+	_, _ = client.Execute(context.Background(), NewReqBuilder().Method(http.MethodGet).PathStatic(pathErr).Build())
+
+	_, _ = client.Execute(context.Background(), NewReqBuilder().Method(http.MethodPost).PathStatic(path5xx).Build())
+	_, _ = client.Execute(context.Background(), NewReqBuilder().Method(http.MethodPost).PathStatic(pathErr).Build())
+
+	type Resp struct {
+		Data string
+	}
+	var resp Resp
+	_ = client.Get(&resp, path5xx, nil)
+	_ = client.Get(&resp, path5xx, nil)
 	_ = client.Get(&resp, pathOk, nil)
+	_ = client.Get(&resp, pathErr, nil)
 
 	_ = client.Post(&resp, path5xx, nil)
-	_ = client.Get(&resp, path5xx, nil)
-
+	_ = client.Post(&resp, path5xx, nil)
+	_ = client.Post(&resp, pathOk, nil)
 	_ = client.Post(&resp, pathErr, nil)
-	_ = client.Get(&resp, pathErr, nil)
-	_ = client.Get(&resp, pathErr, nil)
 
 	mfs, err := reg.Gather()
 	require.NoError(t, err)
 	require.NotNil(t, mfs)
 
-	// metricFamily.Name --> label --> counter value
+	// metricFamily.Name --> Concat(label_name=label_value) --> counter value
 	expected := map[string]map[string]int{
-		metricNameRequestTotal: {
-			"http://www.example.com/ok":  1,
-			"http://www.example.com/5xx": 2,
-			"http://www.example.com/err": 3,
+		namespaceHttpClient + "_" + metricNameRequestTotal: {
+			"app=test method=GET name= status=2xx url=http://www.example.com/ok":    1,
+			"app=test method=GET name= status=5xx url=http://www.example.com/5xx":   1,
+			"app=test method=GET name= status=error url=http://www.example.com/err": 2,
+
+			"app=test method=POST name= status=5xx url=http://www.example.com/5xx":   1,
+			"app=test method=POST name= status=error url=http://www.example.com/err": 1,
+
+			"app=test method=GET name= status=2xx url=http://www.example.com":   1,
+			"app=test method=GET name= status=5xx url=http://www.example.com":   2,
+			"app=test method=GET name= status=error url=http://www.example.com": 1,
+
+			"app=test method=POST name= status=2xx url=http://www.example.com":   1,
+			"app=test method=POST name= status=5xx url=http://www.example.com":   2,
+			"app=test method=POST name= status=error url=http://www.example.com": 1,
 		},
 	}
 
+	testedMetricCount := 0
 	for _, mf := range mfs {
 		expectedLabelCounterMap, ok := expected[*mf.Name]
 		if !ok {
 			continue
 		}
+		testedMetricCount++
 
 		require.Len(t, mf.Metric, len(expectedLabelCounterMap))
 		for _, metric := range mf.Metric {
-			require.Len(t, metric.Label, 2)
-			var chosenLabelIdx = -1
+			labelNameValues := make([]string, len(metric.Label))
 			for idx, label := range metric.Label {
-				if *label.Name == labelNameUrl {
-					chosenLabelIdx = idx
-				}
+				labelNameValues[idx] = fmt.Sprintf("%s=%s", *label.Name, *label.Value)
 			}
-			require.NotEqual(t, -1, chosenLabelIdx)
-			require.Equal(t, float64(expectedLabelCounterMap[*metric.Label[chosenLabelIdx].Value]), *metric.Counter.Value)
+
+			joinedLabels := strings.Join(labelNameValues, " ")
+			expectedCounter := float64(expectedLabelCounterMap[joinedLabels])
+			require.Equal(t, expectedCounter, *metric.Counter.Value)
 		}
 	}
+	require.Equal(t, len(expected), testedMetricCount, "makes sure all expected metrics are tested")
 }
 
 func Test_getHttpReqMetricUrl(t *testing.T) {
 	type args struct {
-		req *http.Request
+		req          *http.Request
+		pathTemplate string
 	}
 	tests := []struct {
 		name string
@@ -109,14 +133,26 @@ func Test_getHttpReqMetricUrl(t *testing.T) {
 		want string
 	}{
 		{
-			name: "example.com",
+			name: "example.com without path template",
 			args: args{
 				req: func() *http.Request {
 					req, _ := http.NewRequest("GET", "http://www.example.com/abc/def", nil)
 					return req
 				}(),
+				pathTemplate: "",
 			},
 			want: "http://www.example.com",
+		},
+		{
+			name: "example.com with path template",
+			args: args{
+				req: func() *http.Request {
+					req, _ := http.NewRequest("GET", "http://www.example.com/abc/def", nil)
+					return req
+				}(),
+				pathTemplate: "/%s/def",
+			},
+			want: "http://www.example.com/%s/def",
 		},
 		{
 			name: "example.com with query params",
@@ -125,23 +161,26 @@ func Test_getHttpReqMetricUrl(t *testing.T) {
 					req, _ := http.NewRequest("GET", "http://www.example.com/abc?param1=a&param2=b", nil)
 					return req
 				}(),
+				pathTemplate: "/%s",
 			},
-			want: "http://www.example.com",
+			want: "http://www.example.com/%s",
 		},
 		{
-			name: "example.com with query params and fragments",
+			name: "example.com with query params and fragments but no pathTemplate",
 			args: args{
 				req: func() *http.Request {
 					req, _ := http.NewRequest("GET", "http://www.example.com?param1=a&param2=b#fragments", nil)
 					return req
 				}(),
+				pathTemplate: "",
 			},
 			want: "http://www.example.com",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, getHttpReqMetricUrl(tt.args.req), "getHttpReqMetricUrl(%v)", tt.args.req)
+			assert.Equalf(t, tt.want, getHttpReqMetricUrl(tt.args.req, tt.args.pathTemplate),
+				"getHttpReqMetricUrl(%v)", tt.args.req)
 		})
 	}
 }

--- a/client/client_metrics_test.go
+++ b/client/client_metrics_test.go
@@ -61,6 +61,12 @@ func TestClientMetrics(t *testing.T) {
 	_, _ = client.Execute(context.Background(), NewReqBuilder().Method(http.MethodPost).PathStatic(path5xx).Build())
 	_, _ = client.Execute(context.Background(), NewReqBuilder().Method(http.MethodPost).PathStatic(pathErr).Build())
 
+	_, _ = client.Execute(context.Background(), NewReqBuilder().
+		Method(http.MethodPost).
+		PathStatic(pathErr).
+		MetricName("postError").
+		Build())
+
 	type Resp struct {
 		Data string
 	}
@@ -88,6 +94,8 @@ func TestClientMetrics(t *testing.T) {
 
 			"app=test method=POST name= status=5xx url=http://www.example.com/5xx":   1,
 			"app=test method=POST name= status=error url=http://www.example.com/err": 1,
+
+			"app=test method=POST name=postError status=error url=http://www.example.com/err": 1,
 
 			"app=test method=GET name= status=2xx url=http://www.example.com":   1,
 			"app=test method=GET name= status=5xx url=http://www.example.com":   2,

--- a/client/jsonrpc.go
+++ b/client/jsonrpc.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -43,7 +44,10 @@ type (
 func (r *Request) RpcCall(result interface{}, method string, params interface{}) error {
 	req := &RpcRequest{JsonRpc: JsonRpcVersion, Method: method, Params: params, Id: genID()}
 	var resp *RpcResponse
-	err := r.Post(&resp, "", req)
+	_, err := r.Execute(context.Background(), NewReqBuilder().
+		WriteTo(&resp).
+		Body(req).
+		Build())
 	if err != nil {
 		return err
 	}
@@ -56,7 +60,10 @@ func (r *Request) RpcCall(result interface{}, method string, params interface{})
 func (r *Request) RpcCallRaw(method string, params interface{}) ([]byte, error) {
 	req := &RpcRequest{JsonRpc: JsonRpcVersion, Method: method, Params: params, Id: genID()}
 	var resp *RpcResponseRaw
-	err := r.Post(&resp, "", req)
+	_, err := r.Execute(context.Background(), NewReqBuilder().
+		WriteTo(&resp).
+		Body(req).
+		Build())
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +75,10 @@ func (r *Request) RpcCallRaw(method string, params interface{}) ([]byte, error) 
 
 func (r *Request) RpcBatchCall(requests RpcRequests) ([]RpcResponse, error) {
 	var resp []RpcResponse
-	err := r.Post(&resp, "", requests.fillDefaultValues())
+	_, err := r.Execute(context.Background(), NewReqBuilder().
+		WriteTo(&resp).
+		Body(requests.fillDefaultValues()).
+		Build())
 	if err != nil {
 		return nil, err
 	}

--- a/client/path.go
+++ b/client/path.go
@@ -1,0 +1,24 @@
+package client
+
+import "fmt"
+
+type Path struct {
+	template string
+	values   []any
+}
+
+func NewStaticPath(path string) Path {
+	return Path{template: path}
+}
+
+func NewEmptyPath() Path {
+	return Path{}
+}
+
+func NewPath(template string, values []any) Path {
+	return Path{template: template, values: values}
+}
+
+func (p Path) String() string {
+	return fmt.Sprintf(p.template, p.values...)
+}

--- a/client/path_test.go
+++ b/client/path_test.go
@@ -1,0 +1,69 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPath_String(t *testing.T) {
+	type fields struct {
+		template string
+		values   []any
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "empty template, empty values",
+			fields: fields{
+				template: "",
+				values:   nil,
+			},
+			want: "",
+		},
+		{
+			name: "empty template only",
+			fields: fields{
+				template: "",
+				values:   []any{1, 2, 3},
+			},
+			want: "%!(EXTRA int=1, int=2, int=3)",
+		},
+		{
+			name: "empty values only",
+			fields: fields{
+				template: "/api/v1/blocks",
+				values:   nil,
+			},
+			want: "/api/v1/blocks",
+		},
+		{
+			name: "both exist",
+			fields: fields{
+				template: "/nft/collections/%s/tokens",
+				values:   []any{"123"},
+			},
+			want: "/nft/collections/123/tokens",
+		},
+		{
+			name: "missing values",
+			fields: fields{
+				template: "/nft/collections/%s/tokens/%d",
+				values:   []any{"123"},
+			},
+			want: "/nft/collections/123/tokens/%!d(MISSING)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Path{
+				template: tt.fields.template,
+				values:   tt.fields.values,
+			}
+			assert.Equalf(t, tt.want, p.String(), "String()")
+		})
+	}
+}

--- a/client/request.go
+++ b/client/request.go
@@ -1,0 +1,90 @@
+package client
+
+import (
+	"net/url"
+)
+
+// Req defines a http request. It is named `Req` instead of `Request` because the http client is named `Request`
+// Consider renaming the client to other name.
+//
+// To build this struct, use NewReqBuilder.
+type Req struct {
+	headers         map[string]string
+	resultContainer any
+	method          string
+	path            Path
+	query           url.Values
+	body            any
+
+	metricName        string
+	pathMetricEnabled bool
+}
+
+type ReqBuilder struct {
+	req *Req
+}
+
+func NewReqBuilder() *ReqBuilder {
+	return &ReqBuilder{
+		req: &Req{
+			headers:           map[string]string{},
+			pathMetricEnabled: true,
+		},
+	}
+}
+
+// Headers sets the headers of the http request. Headers will be overwritten in case of duplicates
+func (builder *ReqBuilder) Headers(headers map[string]string) *ReqBuilder {
+	for k, v := range headers {
+		builder.req.headers[k] = v
+	}
+	return builder
+}
+
+func (builder *ReqBuilder) WriteTo(resultContainer any) *ReqBuilder {
+	builder.req.resultContainer = resultContainer
+	return builder
+}
+
+func (builder *ReqBuilder) Method(method string) *ReqBuilder {
+	builder.req.method = method
+	return builder
+}
+
+// PathStatic sets the path for the request.
+// Use PathStatic ONLY if your path doesn't contain any parameters. Otherwise, use Pathf instead
+func (builder *ReqBuilder) PathStatic(path string) *ReqBuilder {
+	builder.req.path = NewStaticPath(path)
+	return builder
+}
+
+func (builder *ReqBuilder) Pathf(pathTemplate string, values ...any) *ReqBuilder {
+	builder.req.path = NewPath(pathTemplate, values)
+	return builder
+}
+
+func (builder *ReqBuilder) Query(query url.Values) *ReqBuilder {
+	builder.req.query = query
+	return builder
+}
+
+func (builder *ReqBuilder) Body(body any) *ReqBuilder {
+	builder.req.body = body
+	return builder
+}
+
+func (builder *ReqBuilder) MetricName(name string) *ReqBuilder {
+	builder.req.metricName = name
+	return builder
+}
+
+// pathMetricEnabled is only for internal use, where it is set to false
+// in deprecated helper functions such as Get, GetWithContext, Post, PostRaw
+func (builder *ReqBuilder) pathMetricEnabled(enabled bool) *ReqBuilder {
+	builder.req.pathMetricEnabled = enabled
+	return builder
+}
+
+func (builder *ReqBuilder) Build() *Req {
+	return &(*builder.req)
+}


### PR DESCRIPTION
### Problem

1. I am trying to add monitoring for external http requests. Currently URLs are monitored by their actual URL but we ideally want templated URL so it can be grouped. For example, we prefer `/chain/%s/blocks/%d` rather than `/chain/ethereum/blocks/12`
2. The current set of APIs exposed by the http client is IMO a bit clunky which makes it difficult to add this templatedURL monitoring without breaking compatibility

### Solution

Introduces building a request with builder pattern that could be executed it with a new function `Execute(ctx, request)`

### Other Irrelevant Changes
- Sets default timeout to 5seconds
- In InitJSONClient, construct the headers using a new WithExtraHeaders option
- Deprecates Options and functions that modifies internal http.Client (TimeoutOption, ProxyOption, SetTimeout, SetProxy)