### PR TITLE
Re-enable TimeoutOption and ProxyOption, add WithExtraHeader

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -131,6 +131,13 @@ func WithHttpClient(httpClient HTTPClient) Option {
 	}
 }
 
+func WithExtraHeader(key, value string) Option {
+	return func(request *Request) error {
+		request.Headers[key] = value
+		return nil
+	}
+}
+
 func WithExtraHeaders(headers map[string]string) Option {
 	return func(request *Request) error {
 		for k, v := range headers {

--- a/client/client.go
+++ b/client/client.go
@@ -104,7 +104,7 @@ func TimeoutOption(timeout time.Duration) Option {
 			return errors.New("unable to set timeout: httpclient is not *http.Client")
 		}
 
-		setHttpClientTimeout(httpClient, timeout)
+		httpClient.Timeout = timeout
 		return nil
 	}
 }
@@ -198,8 +198,4 @@ func setHttpClientTransportProxy(client *http.Client, proxyUrl string) error {
 	}
 	transport.Proxy = http.ProxyURL(url)
 	return nil
-}
-
-func setHttpClientTimeout(client *http.Client, timeout time.Duration) {
-	client.Timeout = timeout
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -239,6 +239,26 @@ func TestInitClientOptions(t *testing.T) {
 				require.Equal(t, 3*time.Second, client.HttpClient.(*http.Client).Timeout)
 			},
 		},
+		{
+			name: "WithExtraHeader multiple times",
+			options: []Option{
+				WithExtraHeader("Content-Type", "application/json"),
+				WithExtraHeader("Accept", "application/json"),
+				WithExtraHeader("Server", "Apache"),
+				WithExtraHeaders(map[string]string{
+					"Authorization": "Basic <credentials>",
+					"Connection":    "Keep-Alive",
+					"Server":        "nginx",
+				}),
+			},
+			assertion: func(t *testing.T, client *Request) {
+				require.Equal(t, "application/json", client.Headers["Content-Type"])
+				require.Equal(t, "application/json", client.Headers["Accept"])
+				require.Equal(t, "Basic <credentials>", client.Headers["Authorization"])
+				require.Equal(t, "Keep-Alive", client.Headers["Connection"])
+				require.Equal(t, "nginx", client.Headers["Server"])
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR:
- re-enables TimeoutOption, and ProxyOption because the option by itself is fine. The underlying functions SetTimeout and SetProxy are the one that is not ok (changing request internal values after initialization)
- add WithExtraHeader when only adding 1 header