### PR TITLE
fix wrong metric url when baseURL contains sub paths

### DIFF
--- a/client/client_execute.go
+++ b/client/client_execute.go
@@ -76,7 +76,7 @@ func (r *Request) reportMonitoringMetricsIfEnabled(
 	req *Req, res *http.Response, resErr error,
 ) {
 	if r.metricsEnabled() {
-		url := getHttpReqMetricUrl(request, getMonitoredPathTemplateIfEnabled(req))
+		url := r.GetURL(getMonitoredPathTemplateIfEnabled(req), nil)
 		method := request.Method
 		name := req.metricName
 		status := getHttpRespMetricStatus(res, resErr)

--- a/client/client_metrics.go
+++ b/client/client_metrics.go
@@ -66,10 +66,6 @@ func (metric *httpClientMetrics) Collect(metrics chan<- prometheus.Metric) {
 	metric.requestTotal.Collect(metrics)
 }
 
-func getHttpReqMetricUrl(req *http.Request, pathTemplate string) string {
-	return fmt.Sprintf("%s://%s%s", req.URL.Scheme, req.URL.Host, pathTemplate)
-}
-
 func getHttpRespMetricStatus(resp *http.Response, err error) string {
 	if err != nil {
 		return labelValueErr

--- a/client/path_test.go
+++ b/client/path_test.go
@@ -56,6 +56,14 @@ func TestPath_String(t *testing.T) {
 			},
 			want: "/nft/collections/123/tokens/%!d(MISSING)",
 		},
+		{
+			name: "multiple values",
+			fields: fields{
+				template: "/nft/collections/%s/tokens/%s",
+				values:   []any{"123", "bnb"},
+			},
+			want: "/nft/collections/123/tokens/bnb",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Problem

Current implementation will report wrong url in monitoring when the baseURL contains paths too, i.e. it works for `baseURL=http://example.com`, but not when `baseURL=http://example.com/some/path`

When `baseURL=http://example.com/some/path`, currently the reported URL will be the host of the baseURL and the request's path. So if `baseURL=http://example.com/some/path` and `pathTemplate="/blockchain/%s/token/%s"`, the url will be reported as `http://example.com/blockchain/%s/token/%s`

### Solution

Fix by using `url = r.GetURL(getMonitoredPathTemplateIfEnabled(req), nil)`