### PR TITLE
Fix issue with body json decoder

### DIFF
--- a/client/client_execute.go
+++ b/client/client_execute.go
@@ -138,9 +138,16 @@ func (r *Request) metricsEnabled() bool {
 }
 
 func GetBody(body interface{}) (buf io.ReadWriter, err error) {
-	if body != nil {
-		buf = new(bytes.Buffer)
-		err = json.NewEncoder(buf).Encode(body)
+	if body == nil {
+		return
 	}
+
+	var bs []byte
+	bs, err = json.Marshal(body)
+	if err != nil {
+		return
+	}
+
+	buf = bytes.NewBuffer(bs)
 	return
 }


### PR DESCRIPTION
json.NewEncoder adds "\n" at the end of encoded data https://github.com/golang/go/blob/26b48442569102226baba1d9b4a83aaee3d06611/src/encoding/json/stream.go#L196 

This can cause potential issues when requests should be signed. 
Consider this code,

```
req := httpClient.InitClient("https://test.com", nil)

	body := map[string]interface{}{"payload": "data"}
	bbs, _ := json.Marshal(body)
	signature, _ := crypto.HMACSHA256(bbs, "key")

	res, _ := req.
		Execute(context.Background(),
			httpClient.NewReqBuilder().
				Headers(map[string]string{
					"Signature":    string(signature),
					"Content-Type": "application/json",
				}).
				Method(http.MethodPost).
				PathStatic("/test").
				Body(body).
				Build(),
		)
```

the server will not get valid signature because json.Marshall will return `{"payload": "data"}` but request body will be `{"payload": "data"}\n` 