### PR TITLE
Make the binding of exchange and queue happened on the queue side

### DIFF
--- a/cache/redis/redis.go
+++ b/cache/redis/redis.go
@@ -156,3 +156,7 @@ func (r *Redis) Reconnect(ctx context.Context, host string) error {
 
 	return nil
 }
+
+func (r *Redis) Close() error {
+	return r.client.Close()
+}

--- a/mq/exchange.go
+++ b/mq/exchange.go
@@ -7,7 +7,11 @@ type exchange struct {
 
 type Exchange interface {
 	Declare(kind string) error
+	// Deprecated: the binding of exchange and queue should happen on the queue side.
+	// Use Queue.Bind() instead.
 	Bind(queues []Queue) error
+	// Deprecated: the binding of exchange and queue should happen on the queue side.
+	// Use Queue.BindWithKey() instead.
 	BindWithKey(queues []Queue, key ExchangeKey) error
 	Publish(body []byte) error
 	PublishWithKey(body []byte, key ExchangeKey) error
@@ -17,6 +21,8 @@ func (e *exchange) Declare(kind string) error {
 	return e.client.amqpChan.ExchangeDeclare(string(e.name), kind, true, false, false, false, nil)
 }
 
+// Deprecated: the binding of exchange and queue should happen on the queue side.
+// Use Queue.Bind() instead.
 func (e *exchange) Bind(queues []Queue) error {
 	for _, q := range queues {
 		err := e.client.amqpChan.QueueBind(string(q.Name()), "", string(e.name), false, nil)
@@ -28,6 +34,8 @@ func (e *exchange) Bind(queues []Queue) error {
 	return nil
 }
 
+// Deprecated: the binding of exchange and queue should happen on the queue side.
+// Use Queue.BindWithKey() instead.
 func (e *exchange) BindWithKey(queues []Queue, key ExchangeKey) error {
 	for _, q := range queues {
 		err := e.client.amqpChan.QueueBind(string(q.Name()), string(key), string(e.name), false, nil)

--- a/mq/queue.go
+++ b/mq/queue.go
@@ -8,9 +8,25 @@ type queue struct {
 type Queue interface {
 	Declare() error
 	DeclareWithConfig(cfg DeclareConfig) error
+	Bind(exchangeName ExchangeName) error
+	BindWithKey(exchangeName ExchangeName, key ExchangeKey) error
 	Publish(body []byte) error
 	PublishWithConfig(body []byte, cfg PublishConfig) error
 	Name() QueueName
+}
+
+func (q *queue) Bind(exchangeName ExchangeName) error {
+	return q.BindWithKey(exchangeName, "")
+}
+
+func (q *queue) BindWithKey(exchangeName ExchangeName, key ExchangeKey) error {
+	return q.client.amqpChan.QueueBind(
+		string(q.name),
+		string(key),
+		string(exchangeName),
+		false,
+		nil,
+	)
 }
 
 func (q *queue) Name() QueueName {


### PR DESCRIPTION
Two changes:
1. Add `Close` function to `redis` package;
2. Make the binding of exchange and queue happened on the queue side;

In order to decouple the producer and consumer, the binding of `exchange` and `queue` should happen on the `queue` side.

In this way, a producer would only need to know the existence of the `exchange` and be responsible for publishing messages to the `exchange`, without knowing any specific queue.

A consumer is responsible for subscribing to the queue to get messages, and needs to know the binding relationship between itself and the `exchange`. 

```
producer -> exchange(routing_key: "key.#", type: "topic")

exchange(routing_key: "key.#", type: "topic")
-> queue1 (routing_key "key.queue1") -> consumer1
-> queue2 (routing_key "key.queue2") -> consumer2
```

For example, with this change, the producer service will only be responsible for publishing messages to a new `exchange`.

The consumer service can create multiple consumers with different queue names, but binding to the same exchange.
