### PR TITLE
Make worker be dormant

### DIFF
--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -57,7 +57,6 @@ func TestWorkerStartsWithoutExecution(t *testing.T) {
 	options.Interval = -1
 
 	worker := worker.NewWorkerBuilder("test", func() error {
-		time.Sleep(100 * time.Millisecond)
 		counter++
 		return nil
 	}).WithOptions(options).Build()

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/trustwallet/go-libs/worker"
 	"gotest.tools/assert"
+
+	"github.com/trustwallet/go-libs/worker"
 )
 
 func TestWorkerWithDefaultOptions(t *testing.T) {
@@ -26,7 +27,7 @@ func TestWorkerWithDefaultOptions(t *testing.T) {
 	cancel()
 	wg.Wait()
 
-	assert.Equal(t, 4, counter, "Should execute 4 times - 1st immidietly, and 3 after")
+	assert.Equal(t, 4, counter, "Should execute 4 times - 1st immediately, and 3 after")
 }
 
 func TestWorkerStartsConsequently(t *testing.T) {
@@ -49,5 +50,28 @@ func TestWorkerStartsConsequently(t *testing.T) {
 	cancel()
 	wg.Wait()
 
-	assert.Equal(t, 3, counter, "Should execute 3 times - 1st immidietly, and 2 after with delay between runs")
+	assert.Equal(t, 3, counter, "Should execute 3 times - 1st immediately, and 2 after with delay between runs")
+}
+
+func TestWorkerStartsWithoutExecution(t *testing.T) {
+	counter := 0
+	options := worker.DefaultWorkerOptions(100 * time.Millisecond)
+	options.Interval = -1
+
+	worker := worker.NewWorkerBuilder("test", func() error {
+		time.Sleep(100 * time.Millisecond)
+		counter++
+		return nil
+	}).WithOptions(options).Build()
+
+	wg := &sync.WaitGroup{}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	worker.Start(ctx, wg)
+
+	time.Sleep(350 * time.Millisecond)
+	cancel()
+	wg.Wait()
+
+	assert.Equal(t, 0, counter, "Should never be executed")
 }

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -19,12 +19,11 @@ func TestWorkerWithDefaultOptions(t *testing.T) {
 	}).WithOptions(worker.DefaultWorkerOptions(100 * time.Millisecond)).Build()
 
 	wg := &sync.WaitGroup{}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 350*time.Millisecond)
+	defer cancel()
 
 	worker.Start(ctx, wg)
 
-	time.Sleep(350 * time.Millisecond)
-	cancel()
 	wg.Wait()
 
 	assert.Equal(t, 4, counter, "Should execute 4 times - 1st immediately, and 3 after")
@@ -42,12 +41,11 @@ func TestWorkerStartsConsequently(t *testing.T) {
 	}).WithOptions(options).Build()
 
 	wg := &sync.WaitGroup{}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 350*time.Millisecond)
+	defer cancel()
 
 	worker.Start(ctx, wg)
 
-	time.Sleep(350 * time.Millisecond)
-	cancel()
 	wg.Wait()
 
 	assert.Equal(t, 3, counter, "Should execute 3 times - 1st immediately, and 2 after with delay between runs")
@@ -65,12 +63,11 @@ func TestWorkerStartsWithoutExecution(t *testing.T) {
 	}).WithOptions(options).Build()
 
 	wg := &sync.WaitGroup{}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
 
 	worker.Start(ctx, wg)
 
-	time.Sleep(350 * time.Millisecond)
-	cancel()
 	wg.Wait()
 
 	assert.Equal(t, 0, counter, "Should never be executed")


### PR DESCRIPTION
While we migrating workers from Heroku to Kubernetes, we don't expect the same workers are running from different instances, hence, this PR provides the worker the ability to start but never be executed.