### PR TITLE
Extract LoggerFormatter as a separate function

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -5,8 +5,11 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func Logger() gin.HandlerFunc {
-	return gin.LoggerWithFormatter(LoggerFormatter())
+func Logger(skipPaths ...string) gin.HandlerFunc {
+	return gin.LoggerWithConfig(gin.LoggerConfig{
+		Formatter: LoggerFormatter(),
+		SkipPaths: skipPaths,
+	})
 }
 
 func LoggerFormatter() gin.LogFormatter {

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -6,7 +6,11 @@ import (
 )
 
 func Logger() gin.HandlerFunc {
-	return gin.LoggerWithFormatter(func(param gin.LogFormatterParams) string {
+	return gin.LoggerWithFormatter(LoggerFormatter())
+}
+
+func LoggerFormatter() gin.LogFormatter {
+	return func(param gin.LogFormatterParams) string {
 		return fmt.Sprintf("%s - \"%s %s %s %d %s \"%s\" %s\"\n",
 			param.ClientIP,
 			param.Method,
@@ -17,5 +21,5 @@ func Logger() gin.HandlerFunc {
 			param.Request.UserAgent(),
 			param.ErrorMessage,
 		)
-	})
+	}
 }


### PR DESCRIPTION
We will add a health check endpoint to each API service, and the logger should ignore this endpoint. A health check endpoint is often used for monitoring and debugging purposes.

So extracting `LoggerFormatter` can be convenient.