### PR TITLE
Add http metrics

### DIFF
--- a/metrics/http_metrics.go
+++ b/metrics/http_metrics.go
@@ -1,0 +1,106 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"time"
+)
+
+const (
+	requestStartedKey         = "request_started"
+	requestDurationSecondsKey = "request_duration_seconds"
+	requestSucceededTotalKey  = "request_succeeded_total"
+	requestClientErrTotalKey  = "request_client_error_total"
+	requestServerErrTotalKey  = "request_server_error_total"
+)
+
+type HttpServerMetric interface {
+	Start(labelValues ...string) time.Time
+	Duration(start time.Time, labelValues ...string)
+	Success(labelValues ...string)
+	ServerError(labelValues ...string)
+	ClientError(labelValues ...string)
+}
+
+type httpServerMetric struct {
+	requestStarted         *prometheus.GaugeVec
+	requestDurationSeconds *prometheus.HistogramVec
+	requestSucceededTotal  *prometheus.CounterVec
+	requestClientErrTotal  *prometheus.CounterVec
+	requestServerErrTotal  *prometheus.CounterVec
+}
+
+func NewHttpServerMetric(
+	namespace string,
+	labelNames []string,
+	staticLabels prometheus.Labels,
+	reg prometheus.Registerer,
+) HttpServerMetric {
+	requestStarted := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      requestStartedKey,
+		Help:      "Last Unix time when request started.",
+	}, labelNames)
+
+	requestDurationSeconds := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      requestDurationSecondsKey,
+		Help:      "Duration of the executions.",
+	}, labelNames)
+
+	requestSucceededTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      requestSucceededTotalKey,
+		Help:      "Total number of the 2xx requests which succeeded.",
+	}, labelNames)
+
+	requestClientErrTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      requestClientErrTotalKey,
+		Help:      "Total number of the 4xx requests.",
+	}, labelNames)
+
+	requestServerErrTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      requestServerErrTotalKey,
+		Help:      "Total number of the 5xx requests.",
+	}, labelNames)
+
+	Register(staticLabels, reg, requestStarted, requestDurationSeconds, requestSucceededTotal, requestClientErrTotal, requestServerErrTotal)
+
+	return &httpServerMetric{
+		requestStarted:         requestStarted,
+		requestDurationSeconds: requestDurationSeconds,
+		requestSucceededTotal:  requestSucceededTotal,
+		requestClientErrTotal:  requestClientErrTotal,
+		requestServerErrTotal:  requestServerErrTotal,
+	}
+}
+
+func (m *httpServerMetric) Start(labelValues ...string) time.Time {
+	start := time.Now()
+	m.requestStarted.WithLabelValues(labelValues...).SetToCurrentTime()
+	return start
+}
+
+func (m *httpServerMetric) Duration(start time.Time, labelValues ...string) {
+	duration := time.Since(start)
+	m.requestDurationSeconds.WithLabelValues(labelValues...).Observe(duration.Seconds())
+}
+
+func (m *httpServerMetric) Success(labelValues ...string) {
+	m.requestSucceededTotal.WithLabelValues(labelValues...).Inc()
+	m.requestServerErrTotal.WithLabelValues(labelValues...).Add(0)
+	m.requestClientErrTotal.WithLabelValues(labelValues...).Add(0)
+}
+
+func (m *httpServerMetric) ServerError(labelValues ...string) {
+	m.requestSucceededTotal.WithLabelValues(labelValues...).Add(0)
+	m.requestServerErrTotal.WithLabelValues(labelValues...).Inc()
+	m.requestClientErrTotal.WithLabelValues(labelValues...).Add(0)
+}
+
+func (m *httpServerMetric) ClientError(labelValues ...string) {
+	m.requestSucceededTotal.WithLabelValues(labelValues...).Add(0)
+	m.requestServerErrTotal.WithLabelValues(labelValues...).Add(0)
+	m.requestClientErrTotal.WithLabelValues(labelValues...).Inc()
+}


### PR DESCRIPTION
When we began using Grafana for monitoring and alerting, the #monitoring-channel was being spammed because `4xx` status codes were being treated as failed requests. 

However, 4xx should not be considered "failures", but we still need to keep track of them. So, I duplicated the `httpMetrics` from `performanceMetrics`. Unlike `performanceMetrics`, it doesn't simply judge success or failure, but it is divided into success, client error and server error. 

With this change, we were able to adjust the alarms.