### PR TITLE
client: support host

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -139,7 +139,7 @@ func WithExtraHeader(key, value string) Option {
 	}
 }
 
-func HostOption(host string) Option {
+func WithHost(host string) Option {
 	return func(request *Request) error {
 		request.Host = host
 		return nil

--- a/client/client.go
+++ b/client/client.go
@@ -139,6 +139,13 @@ func WithExtraHeader(key, value string) Option {
 	}
 }
 
+func HostOption(host string) Option {
+	return func(request *Request) error {
+		request.Host = host
+		return nil
+	}
+}
+
 func WithExtraHeaders(headers map[string]string) Option {
 	return func(request *Request) error {
 		for k, v := range headers {

--- a/client/client.go
+++ b/client/client.go
@@ -17,6 +17,7 @@ const defaultTimeout = 5 * time.Second
 type Request struct {
 	BaseURL          string
 	Headers          map[string]string
+	Host             string
 	HttpClient       HTTPClient
 	HttpErrorHandler HttpErrorHandler
 

--- a/client/client_execute.go
+++ b/client/client_execute.go
@@ -68,6 +68,10 @@ func (r *Request) constructHttpRequest(ctx context.Context, req *Req) (*http.Req
 	}
 
 	r.setRequestHeaders(request, req)
+
+	if req.host != "" {
+		request.Host = req.host
+	}
 	return request, nil
 }
 

--- a/client/client_execute.go
+++ b/client/client_execute.go
@@ -69,8 +69,8 @@ func (r *Request) constructHttpRequest(ctx context.Context, req *Req) (*http.Req
 
 	r.setRequestHeaders(request, req)
 
-	if req.host != "" {
-		request.Host = req.host
+	if r.Host != "" {
+		request.Host = r.Host
 	}
 	return request, nil
 }

--- a/client/request.go
+++ b/client/request.go
@@ -15,7 +15,6 @@ type Req struct {
 	path            Path
 	query           url.Values
 	body            any
-	host            string
 
 	metricName        string
 	pathMetricEnabled bool

--- a/client/request.go
+++ b/client/request.go
@@ -15,6 +15,7 @@ type Req struct {
 	path            Path
 	query           url.Values
 	body            any
+	host            string
 
 	metricName        string
 	pathMetricEnabled bool


### PR DESCRIPTION
I want to send request to some nodes that require custom `Host` header,
I tried to add `Host` to golang `http.Request`and it didn't work. After research, I found that I have to use `Request.Host` instead of `Request.Header.Set("Host")`
[Golang Issue](https://github.com/golang/go/issues/29865)