### PR TITLE
implement get bytes & set bytes

### DIFF
--- a/cache/redis/redis.go
+++ b/cache/redis/redis.go
@@ -88,6 +88,17 @@ func (r *Redis) Get(ctx context.Context, key string, receiver interface{}) error
 	return nil
 }
 
+func (r *Redis) GetBytes(ctx context.Context, key string) ([]byte, error) {
+	cmd := r.client.Get(ctx, key)
+	if errors.Is(cmd.Err(), redis.Nil) {
+		return nil, ErrNotFound
+	} else if cmd.Err() != nil {
+		return nil, cmd.Err()
+	}
+
+	return cmd.Bytes()
+}
+
 // MGet returns slice with length == len(key)
 // Resulting slice's item is nil if there is no value in cache
 func (r *Redis) MGet(ctx context.Context, key ...string) ([][]byte, error) {
@@ -113,6 +124,15 @@ func (r *Redis) Set(ctx context.Context, key string, value interface{}, expirati
 	}
 
 	cmd := r.client.Set(ctx, key, data, expiration)
+	if cmd.Err() != nil {
+		return cmd.Err()
+	}
+
+	return nil
+}
+
+func (r *Redis) SetBytes(ctx context.Context, key string, value []byte, expiration time.Duration) error {
+	cmd := r.client.Set(ctx, key, value, expiration)
 	if cmd.Err() != nil {
 		return cmd.Err()
 	}


### PR DESCRIPTION
### Problem

I am planning to store []bytes into redis. Currently our client will do json.Marshal, and this converts the []bytes into base64 encoded string as per [the doc](https://pkg.go.dev/encoding/json#Marshal:~:text=%5B%5Dbyte%20encodes%20as%20a%20base64%2Dencoded%20string):
>  []byte encodes as a base64-encoded string,

This behaviour is fine functionality wise, but it increases the amount of memory stored in redis as per my testing:

Storing with base64 encoded string takes 280 bytes of memory:
```
127.0.0.1:51151> MEMORY USAGE assets:bloom
(integer) 280
127.0.0.1:51151> get assets:bloom
"\"AAAAAAAAA78AAAAAAAAABwAAAAAAAAO/Yi1zGbNDo16zF+fkKxjWphJZ4THcFaULd/9XfosoIIfjifQT6toStPrTXsoN1uvDMBqHs/+D3wzSeLlePN5fqxpDuMS2DCL8R6pZ7F9UJgP0xJTHy0Dtojr6artFrxhr2luUjiKqzCoB9P9ClHSB6As3boWVhooO\""
```

Storing []bytes directly into redis, takes 216 bytes
```
127.0.0.1:51134> MEMORY USAGE assets:bloom
(integer) 216
127.0.0.1:51134> get assets:bloom
"\x00\x00\x00\x00\x00\x00\x03\xbf\x00\x00\x00\x00\x00\x00\x00\a\x00\x00\x00\x00\x00\x00\x03\xbfb-s\x19\xb3C\xa3^\xb3\x17\xe7\xe4+\x18\xd6\xa6\x12Y\xe11\xdc\x15\xa5\x0bw\xffW~\x8b( \x87\xe3\x89\xf4\x13\xea\xda\x12\xb4\xfa\xd3^\xca\r\xd6\xeb\xc30\x1a\x87\xb3\xff\x83\xdf\x0c\xd2x\xb9^<\xde_\xab\x1aC\xb8\xc4\xb6\x0c\"\xfcG\xaaY\xec_T&\x03\xf4\xc4\x94\xc7\xcb@\xed\xa2:\xfaj\xbbE\xaf\x18k\xda[\x94\x8e\"\xaa\xcc*\x01\xf4\xffB\x94t\x81\xe8\x0b7n\x85\x95\x86\x8a\x0e"
```

The object that I want to store may be sizable, so I want this optimization

### Solution

Adding a function that stores bytes directly in redis