### PR TITLE
Fix dependency version of `logrus_mate`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/golang/mock v1.6.0
 	github.com/heirko/go-contrib v0.0.0-20200825160048-11fc5e2235fa
-	github.com/heralight/logrus_mate v1.0.1
+	github.com/heralight/logrus_mate v1.0.1-0.20170807195635-969b6efb860e
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.12.0
 	github.com/sirupsen/logrus v1.8.1
@@ -19,6 +19,7 @@ require (
 	github.com/streadway/amqp v1.0.0
 	github.com/stretchr/testify v1.8.3
 	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
+	golang.org/x/net v0.10.0
 	golang.org/x/sync v0.1.0
 	gorm.io/driver/postgres v1.4.7
 	gorm.io/gorm v1.24.3
@@ -89,7 +90,6 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/crypto v0.9.0 // indirect
-	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -688,8 +688,8 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/heirko/go-contrib v0.0.0-20200825160048-11fc5e2235fa h1:TcT7Ll6YpAFhTfk4JQz1XZ7aTaKWVQsxQQSio8B3dBs=
 github.com/heirko/go-contrib v0.0.0-20200825160048-11fc5e2235fa/go.mod h1:+XqKin+DP4zEu3b0QJ3KyJqYuHzCV0TmmVXCtstKlNY=
-github.com/heralight/logrus_mate v1.0.1 h1:9qe6YNySFd2ERcJFLzC7q0E6HSdZW1afeuODz1+h4w0=
-github.com/heralight/logrus_mate v1.0.1/go.mod h1:FOZ+u9G+H/0QI9OJa6Y2yRO7Du0l5b8CIYbmQ3fGzD4=
+github.com/heralight/logrus_mate v1.0.1-0.20170807195635-969b6efb860e h1:gKma69qkc6EbZXY7MznbxAuW0/Kyv+j+nUsYdrvKayE=
+github.com/heralight/logrus_mate v1.0.1-0.20170807195635-969b6efb860e/go.mod h1:FOZ+u9G+H/0QI9OJa6Y2yRO7Du0l5b8CIYbmQ3fGzD4=
 github.com/hoisie/redis v0.0.0-20160730154456-b5c6e81454e0 h1:mjZV3MTu2A5gwfT5G9IIiLGdwZNciyVq5qqnmJJZ2JI=
 github.com/hoisie/redis v0.0.0-20160730154456-b5c6e81454e0/go.mod h1:pMYMxVaKJqCDC1JUg/XbPJ4/fSazB25zORpFzqsIGIc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=


### PR DESCRIPTION
The repository https://github.com/heralight/logrus_mate/tags does not have a tag named `v1.0.1`. Instead, there is a branch named `v0.1.1`. This discrepancy results in a warning when using go mod:

```
go: github.com/heralight/logrus_mate@v1.0.1: invalid version: resolves to version v1.0.1-0.20170807195635-969b6efb860e (v1.0.1 is not a tag)
```

This PR addresses this issue by replacing the branch name with the commit hash to prevent confusion within `go mod`.