### PR TITLE
Support prefetch limit per consumer. 

### DIFF
--- a/mq/mq.go
+++ b/mq/mq.go
@@ -24,8 +24,10 @@ const (
 )
 
 type Client struct {
-	url      string
-	conn     *amqp.Connection
+	url  string
+	conn *amqp.Connection
+
+	// This channel should only be used for management related operations, like declaring queues & exchanges
 	amqpChan *amqp.Channel
 
 	connClients []ConnectionClient

--- a/mq/options.go
+++ b/mq/options.go
@@ -27,6 +27,13 @@ func DefaultConsumerOptions(workers int) *ConsumerOptions {
 	}
 }
 
+// Deprecated: We should not put prefetch limit at channel level. We need to set limit at consumer level
+// This option no longer works to limit QoS globally.
+//
+// From rabbitMQ doc https://www.rabbitmq.com/consumer-prefetch.html
+// Unfortunately the channel is not the ideal scope for this - since a single channel may consume from multiple queues,
+// the channel and the queue(s) need to coordinate with each other for every message sent to ensure they don't go over
+// the limit. This is slow on a single machine, and very slow when consuming across a cluster.
 func OptionPrefetchLimit(limit int) Option {
 	return func(m *Client) error {
 		err := m.amqpChan.Qos(


### PR DESCRIPTION
- Deprecate Global OptionPrefetchLimit
- Create a dedicated channel for every consumer
- For every consumer's dedicated channel, set Prefetch to be equal to the number of `c.options.Workers`

Tested in Chronos, I run two consumers for ethereum and smartchain, workers are set to 1 for each chain. We can see Unacked is 1 for each chain
<img width="808" alt="Screenshot 2023-08-28 at 16 54 14" src="https://github.com/trustwallet/go-libs/assets/4551581/4d3ce910-3ef7-4a50-881d-117630b8be77">

