### PR TITLE
add err body

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -37,7 +37,12 @@ type HttpError struct {
 }
 
 func (e *HttpError) Error() string {
-	return fmt.Sprintf("Failed request status %d for url: (%s)", e.StatusCode, e.URL.RequestURI())
+	return fmt.Sprintf(
+		"Failed request status %d for url: (%s), body: (%s)",
+		e.StatusCode,
+		e.URL.RequestURI(),
+		string(e.Body),
+	)
 }
 
 type HttpErrorHandler func(res *http.Response, uri string) error


### PR DESCRIPTION
Some logs in atlas unhelpful, you should spend time to reproduce the request with curl to see error body and sometimes it is hard to do locally e.g. 429 too many requests in Prod but one curl call is ok locally