### PR TITLE
feat(sc-52274): add status label to request_* http metrics

### DIFF
--- a/middleware/metrics_test.go
+++ b/middleware/metrics_test.go
@@ -27,49 +27,68 @@ func TestMetricsMiddleware(t *testing.T) {
 	router.GET("/error", func(c *gin.Context) {
 		_ = c.AbortWithError(http.StatusInternalServerError, errors.New("oops error"))
 	})
+	router.GET("/404", func(c *gin.Context) {
+		_ = c.AbortWithError(http.StatusNotFound, errors.New("404"))
+	})
 
 	// 2 successes, 1 errors
 	_ = performRequest("GET", "/success?haha=1&hoho=2", router)
 	_ = performRequest("GET", "/error?hehe=1&huhu=3", router)
 	_ = performRequest("GET", "/success/hihi", router)
+	_ = performRequest("GET", "/404", router)
 
 	metricFamilies, err := r.Gather()
 	require.NoError(t, err)
-
-	const executionFailedTotal = "execution_failed_total"
-	const executionSucceededTotal = "execution_succeeded_total"
-
+	const (
+		requestSucceededTotalKey = "request_succeeded_total"
+		requestClientErrTotalKey = "request_client_error_total"
+		requestServerErrTotalKey = "request_server_error_total"
+	)
 	// metricFamily.Name --> label --> counter value
 	expected := map[string]map[string]int{
-		executionSucceededTotal: {
+		requestSucceededTotalKey: {
 			"/success":       1,
 			"/success/:test": 1,
 			"/error":         0,
+			"/404":           0,
 		},
-		executionFailedTotal: {
+		requestServerErrTotalKey: {
 			"/success":       0,
 			"/success/:test": 0,
 			"/error":         1,
+			"/404":           0,
+		},
+		requestClientErrTotalKey: {
+			"/success":       0,
+			"/success/:test": 0,
+			"/error":         0,
+			"/404":           1,
 		},
 	}
-
 	for _, metricFamily := range metricFamilies {
 		expectedLabelCounterMap, ok := expected[*metricFamily.Name]
 		if !ok {
 			continue
 		}
-
 		require.Len(t, metricFamily.Metric, len(expectedLabelCounterMap))
 		for _, metric := range metricFamily.Metric {
-			require.Len(t, metric.Label, 2)
-			var chosenLabelIdx = -1
-			for idx, label := range metric.Label {
-				if *label.Name == labelPath {
-					chosenLabelIdx = idx
-				}
+			require.Len(t, metric.Label, 3)
+			labelIndexes := map[string]int{
+				labelMethod: -1,
+				labelPath:   -1,
+				labelStatus: -1,
 			}
-			require.NotEqual(t, -1, chosenLabelIdx)
-			require.Equal(t, float64(expectedLabelCounterMap[*metric.Label[chosenLabelIdx].Value]), *metric.Counter.Value)
+			for idx, label := range metric.Label {
+				labelIndexes[*label.Name] = idx
+			}
+			require.Equal(t, len(labelIndexes), 3)
+			for _, labelIdx := range labelIndexes {
+				require.NotEqual(t, -1, labelIdx)
+			}
+			pathIdx := labelIndexes[labelPath]
+			path := *metric.Label[pathIdx].Value
+			expectedPathMetric := float64(expectedLabelCounterMap[path])
+			require.Equal(t, expectedPathMetric, *metric.Counter.Value)
 		}
 	}
 }


### PR DESCRIPTION
This pull request includes changes to the `middleware/metrics.go` and `middleware/metrics_test.go` files to enhance the metrics middleware by adding status code tracking and updating the corresponding tests. The most important changes include adding status code labels, updating the metrics middleware to record status codes, and modifying the tests to validate the new status code metrics.

Enhancements to metrics middleware:

* [`middleware/metrics.go`](diffhunk://#diff-dbb730e5adef2e6dc425d22a920aab9293b9bb063d87886a072d99491ae274a1R14-R24): Added a new label `labelStatus` to track HTTP status codes and updated the `MetricsMiddleware` function to include this label in the metrics.
* [`middleware/metrics.go`](diffhunk://#diff-dbb730e5adef2e6dc425d22a920aab9293b9bb063d87886a072d99491ae274a1L25-L31): Modified the `MetricsMiddleware` function to record the status code of each request and include it in the label values.

Updates to tests:

* [`middleware/metrics_test.go`](diffhunk://#diff-f1e387da4ec57935bc68ad945c1debf9dda6ad424eb8a89a271dae5b4c027aabR30-R91): Added a new route `/404` to simulate a 404 error and updated the test cases to include this new route.
* [`middleware/metrics_test.go`](diffhunk://#diff-f1e387da4ec57935bc68ad945c1debf9dda6ad424eb8a89a271dae5b4c027aabR30-R91): Updated the expected metrics to include new keys for client and server errors, and modified the assertions to check for the new status code label.